### PR TITLE
fix: account for unreferenced calendar entries

### DIFF
--- a/lib/gtfs_df/feed.rb
+++ b/lib/gtfs_df/feed.rb
@@ -432,21 +432,22 @@ module GtfsDf
               # union semantics across those two parents (a trip is valid if it appears in
               # either).
               #
-              # Here we accumulate valid service_ids across calendar/calendar_dates, but only
-              # within the pool of trips that are already reachable from structural parents.
+              # Accumulate service_ids from each calendar source, then apply the filter.
+              # If the filter results in 0 trips, we continue accumulating to allow the next
+              # calendar edge to add valid service_ids. This handles feeds where
+              # calendar.txt has unreferenced service_ids but all trips use
+              # calendar_dates.txt service_ids.
               accumulated_service_ids = Polars.concat([accumulated_service_ids, valid_values]).unique
-
-              # Determine the base pool of trips:
-              # - If we've already restricted trips via structural parents (routes,
-              #   stop_times, shapes, etc), use that as the base.
-              # - Otherwise, like when filtering directly on trips, use the current
-              #   trips dataframe.
               trips_base_df ||= filtered[child_node.fetch(:file)]
               next unless trips_base_df && trips_base_df.height > 0
 
-              filtered[child_node.fetch(:file)] = trips_base_df.filter(
+              filtered_trips = trips_base_df.filter(
                 Polars.col("service_id").is_in(accumulated_service_ids.implode)
               )
+
+              if filtered_trips.height > 0
+                filtered[child_node.fetch(:file)] = filtered_trips
+              end
             else
               # Original single-edge logic for all other nodes
               before = child_df.height

--- a/spec/gtfs_df/feed_spec.rb
+++ b/spec/gtfs_df/feed_spec.rb
@@ -894,4 +894,52 @@ RSpec.describe GtfsDf::Feed do
       end
     end
   end
+
+  describe "unreferenced service_ids in calendar.txt" do
+    let(:trips_df) do
+      Polars::DataFrame.new({
+        "trip_id" => %w[t1 t2],
+        "route_id" => %w[1 2],
+        "service_id" => %w[calendar_dates_service calendar_dates_service]
+      })
+    end
+    let(:stop_times_df) do
+      Polars::DataFrame.new({
+        "trip_id" => %w[t1 t1 t2 t2],
+        "stop_id" => %w[S1 S2 S2 S3],
+        "stop_sequence" => [1, 2, 1, 2]
+      })
+    end
+    let(:calendar_df) do
+      Polars::DataFrame.new({
+        "service_id" => ["unused_service"],
+        "monday" => ["1"],
+        "tuesday" => ["1"],
+        "wednesday" => ["1"],
+        "thursday" => ["1"],
+        "friday" => ["1"],
+        "saturday" => ["1"],
+        "sunday" => ["1"],
+        "start_date" => ["20250101"],
+        "end_date" => ["20251231"]
+      })
+    end
+    let(:calendar_dates_df) do
+      Polars::DataFrame.new({
+        "service_id" => %w[calendar_dates_service calendar_dates_service],
+        "date" => %w[20250304 20250427],
+        "exception_type" => [1, 1]
+      })
+    end
+
+    it "preserves trips from calendar_dates service when calendar has unused service_ids" do
+      view = {"trips" => {"trip_id" => ->(_) { true }}}
+      filtered = feed.filter(view)
+
+      expect(filtered.calendar).to be_nil
+      expect(filtered.calendar_dates["service_id"].unique.to_a).to eq(%w[calendar_dates_service])
+      expect(filtered.routes["route_id"].to_a).to match_array(%w[1 2])
+      expect(filtered.trips["trip_id"].to_a).to match_array(%w[t1 t2])
+    end
+  end
 end

--- a/spec/gtfs_df/feed_spec.rb
+++ b/spec/gtfs_df/feed_spec.rb
@@ -942,4 +942,52 @@ RSpec.describe GtfsDf::Feed do
       expect(filtered.trips["trip_id"].to_a).to match_array(%w[t1 t2])
     end
   end
+
+  describe "unreferenced service_ids in calendar_dates.txt" do
+    let(:trips_df) do
+      Polars::DataFrame.new({
+        "trip_id" => %w[t1 t2],
+        "route_id" => %w[1 2],
+        "service_id" => %w[calendar_service calendar_service]
+      })
+    end
+    let(:stop_times_df) do
+      Polars::DataFrame.new({
+        "trip_id" => %w[t1 t1 t2 t2],
+        "stop_id" => %w[S1 S2 S2 S3],
+        "stop_sequence" => [1, 2, 1, 2]
+      })
+    end
+    let(:calendar_df) do
+      Polars::DataFrame.new({
+        "service_id" => %w[calendar_service],
+        "monday" => %w[1],
+        "tuesday" => %w[1],
+        "wednesday" => %w[1],
+        "thursday" => %w[1],
+        "friday" => %w[1],
+        "saturday" => %w[1],
+        "sunday" => %w[1],
+        "start_date" => %w[20250101],
+        "end_date" => %w[20251231]
+      })
+    end
+    let(:calendar_dates_df) do
+      Polars::DataFrame.new({
+        "service_id" => %w[unused_dates_service],
+        "date" => %w[20250304],
+        "exception_type" => [1]
+      })
+    end
+
+    it "preserves trips from calendar service when calendar_dates has unused service_ids" do
+      view = {"trips" => {"trip_id" => ->(_) { true }}}
+      filtered = feed.filter(view)
+
+      expect(filtered.calendar["service_id"].unique.to_a).to eq(%w[calendar_service])
+      expect(filtered.calendar_dates).to be_nil
+      expect(filtered.routes["route_id"].to_a).to match_array(%w[1 2])
+      expect(filtered.trips["trip_id"].to_a).to match_array(%w[t1 t2])
+    end
+  end
 end


### PR DESCRIPTION
Ensure we don't accidentally prune trips from feeds where all the trips come from calendar_dates and there are unreferenced calendar entries.

